### PR TITLE
Create Java MD5 with salt example

### DIFF
--- a/Java MD5 with salt example
+++ b/Java MD5 with salt example
@@ -1,0 +1,53 @@
+public class SaltedMD5Example 
+{
+    public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchProviderException 
+    {
+        String passwordToHash = "password";
+        byte[] salt = getSalt();
+         
+        String securePassword = getSecurePassword(passwordToHash, salt);
+        System.out.println(securePassword); //Prints 83ee5baeea20b6c21635e4ea67847f66
+         
+        String regeneratedPassowrdToVerify = getSecurePassword(passwordToHash, salt);
+        System.out.println(regeneratedPassowrdToVerify); //Prints 83ee5baeea20b6c21635e4ea67847f66
+    }
+     
+    private static String getSecurePassword(String passwordToHash, byte[] salt)
+    {
+        String generatedPassword = null;
+        try {
+            // Create MessageDigest instance for MD5
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            //Add password bytes to digest
+            md.update(salt);
+            //Get the hash's bytes 
+            byte[] bytes = md.digest(passwordToHash.getBytes());
+            //This bytes[] has bytes in decimal format;
+            //Convert it to hexadecimal format
+            StringBuilder sb = new StringBuilder();
+            for(int i=0; i< bytes.length ;i++)
+            {
+                sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
+            }
+            //Get complete hashed password in hex format
+            generatedPassword = sb.toString();
+        } 
+        catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return generatedPassword;
+    }
+     
+    //Add salt
+    private static byte[] getSalt() throws NoSuchAlgorithmException, NoSuchProviderException
+    {
+        //Always use a SecureRandom generator
+        SecureRandom sr = SecureRandom.getInstance("SHA1PRNG", "SUN");
+        //Create array for salt
+        byte[] salt = new byte[16];
+        //Get a random salt
+        sr.nextBytes(salt);
+        //return salt
+        return salt;
+    }
+}


### PR DESCRIPTION
The original intent of salting was primarily to defeat pre-computed rainbow table attacks that could otherwise be used to greatly improve the efficiency of cracking the hashed password database. A greater benefit now is to slow down parallel operations that compare the hash of a password guess against many password hashes at once.